### PR TITLE
Problem with other annotations while using Route

### DIFF
--- a/bundle/Spec/CirclicalAutoWire/Annotations/OtherAnnotation.php
+++ b/bundle/Spec/CirclicalAutoWire/Annotations/OtherAnnotation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spec\CirclicalAutoWire\Annotations;
+
+/**
+ * Class OtherAnnotation
+ *
+ * @package Spec\CirclicalAutoWire\Annotations
+ * @author Michał Makaruk <buliq1847@gmail.com>
+ *
+ * @Annotation
+ * @Target({"METHOD","CLASS"})
+ */
+final class OtherAnnotation
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+}

--- a/bundle/Spec/CirclicalAutoWire/Controller/OtherAnnotationsController.php
+++ b/bundle/Spec/CirclicalAutoWire/Controller/OtherAnnotationsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spec\CirclicalAutoWire\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use CirclicalAutoWire\Annotations\Route;
+use Spec\CirclicalAutoWire\Annotations\OtherAnnotation;
+
+/**
+ * Class OtherAnnotationsTypeErrorController
+ * @package Spec\CirclicalAutoWire\Controller
+ *
+ * @Route("/foobar")
+ */
+class OtherAnnotationsController extends AbstractActionController
+{
+    /**
+     * @Route("/")
+     */
+    public function fooAction()
+    {
+    }
+
+    /**
+     * @OtherAnnotation
+     * @Route("/ok")
+     */
+    public function willItFailAction()
+    {
+    }
+
+}

--- a/bundle/Spec/CirclicalAutoWire/Controller/OtherAnnotationsTypeErrorController.php
+++ b/bundle/Spec/CirclicalAutoWire/Controller/OtherAnnotationsTypeErrorController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spec\CirclicalAutoWire\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use CirclicalAutoWire\Annotations\Route;
+use Spec\CirclicalAutoWire\Annotations\OtherAnnotation;
+
+/**
+ * Class OtherAnnotationsTypeErrorController
+ * @package Spec\CirclicalAutoWire\Controller
+ *
+ */
+class OtherAnnotationsTypeErrorController extends AbstractActionController
+{
+    /**
+     * @OtherAnnotation
+     * @Route("/will-it-fail")
+     */
+    public function willItFailAction()
+    {
+    }
+
+}

--- a/bundle/Spec/CirclicalAutoWire/Service/RouterServiceSpec.php
+++ b/bundle/Spec/CirclicalAutoWire/Service/RouterServiceSpec.php
@@ -225,7 +225,7 @@ class RouterServiceSpec extends ObjectBehavior
         $this->compile();
     }
 
-    function it_skips_other_annotations($routerStack)
+    function it_skips_other_annotations()
     {
         include __DIR__ . '/../../CirclicalAutoWire/Controller/OtherAnnotationsController.php';
         AnnotationRegistry::registerAutoloadNamespace("Spec\\CirclicalAutoWire\\Annotations", realpath(__DIR__ . "/../../../"));
@@ -233,7 +233,7 @@ class RouterServiceSpec extends ObjectBehavior
         $this->shouldNotThrow(\Error::class)->during('parseController', [OtherAnnotationsController::class]);
     }
 
-    function it_skips_other_annotations_type_error($routerStack)
+    function it_skips_other_annotations_type_error()
     {
         include __DIR__ . '/../../CirclicalAutoWire/Controller/OtherAnnotationsTypeErrorController.php';
         AnnotationRegistry::registerAutoloadNamespace("Spec\\CirclicalAutoWire\\Annotations", realpath(__DIR__ . "/../../../"));

--- a/bundle/Spec/CirclicalAutoWire/Service/RouterServiceSpec.php
+++ b/bundle/Spec/CirclicalAutoWire/Service/RouterServiceSpec.php
@@ -2,9 +2,12 @@
 
 namespace Spec\CirclicalAutoWire\Service;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Spec\CirclicalAutoWire\Controller\AnnotatedController;
 use Spec\CirclicalAutoWire\Controller\ChildRouteController;
 use Spec\CirclicalAutoWire\Controller\DistantChildRouteController;
+use Spec\CirclicalAutoWire\Controller\OtherAnnotationsController;
+use Spec\CirclicalAutoWire\Controller\OtherAnnotationsTypeErrorController;
 use Spec\CirclicalAutoWire\Controller\SameNameAController;
 use Spec\CirclicalAutoWire\Controller\SameNameBController;
 use Spec\CirclicalAutoWire\Controller\SimpleController;
@@ -220,5 +223,23 @@ class RouterServiceSpec extends ObjectBehavior
         $this->parseController(SameNameAController::class);
         $this->parseController(SameNameBController::class);
         $this->compile();
+    }
+
+    function it_skips_other_annotations($routerStack)
+    {
+        include __DIR__ . '/../../CirclicalAutoWire/Controller/OtherAnnotationsController.php';
+        AnnotationRegistry::registerAutoloadNamespace("Spec\\CirclicalAutoWire\\Annotations", realpath(__DIR__ . "/../../../"));
+
+        $this->shouldNotThrow(\Error::class)->during('parseController', [OtherAnnotationsController::class]);
+    }
+
+    function it_skips_other_annotations_type_error($routerStack)
+    {
+        include __DIR__ . '/../../CirclicalAutoWire/Controller/OtherAnnotationsTypeErrorController.php';
+        AnnotationRegistry::registerAutoloadNamespace("Spec\\CirclicalAutoWire\\Annotations", realpath(__DIR__ . "/../../../"));
+
+        //this should be thrown, but I'm unable to force it...
+//        $this->shouldThrow(\TypeError::class)->during('parseController', [OtherAnnotationsTypeErrorController::class]);
+        $this->shouldNotThrow(\PhpSpec\Exception\Example\ErrorException::class)->during('parseController', [OtherAnnotationsTypeErrorController::class]);
     }
 }

--- a/src/CirclicalAutoWire/Model/AnnotatedRoute.php
+++ b/src/CirclicalAutoWire/Model/AnnotatedRoute.php
@@ -44,7 +44,7 @@ final class AnnotatedRoute
     public function toArray(): array
     {
         $route = [
-            'type' => $this->type ?? $this->identifyRoute($this->route->value),
+            'type' => $this->type ?? $this->route->type ?? $this->identifyRoute($this->route->value),
             'options' => [
                 'route' => $this->route->value,
                 'defaults' => [

--- a/src/CirclicalAutoWire/Module.php
+++ b/src/CirclicalAutoWire/Module.php
@@ -83,6 +83,12 @@ class Module
             $writer = new PhpArray();
             $writer->toFile($config['circlical']['autowire']['compile_to'], $routeConfig, true);
             $routerService->reset();
+
+            /** @var \Zend\ModuleManager\Listener\ConfigListener $cfg */
+            $cfg = $serviceLocator->get(\Zend\ModuleManager\ModuleManager::class)->getEvent()->getConfigListener();
+            if ($productionMode && $cfg->getOptions()->getConfigCacheEnabled() && file_exists($cfg->getOptions()->getConfigCacheFile())) {
+                @unlink($cfg->getOptions()->getConfigCacheFile());
+            }
         }
     }
 }

--- a/src/CirclicalAutoWire/Module.php
+++ b/src/CirclicalAutoWire/Module.php
@@ -59,7 +59,7 @@ class Module
         $config = $serviceLocator->get('config');
         $productionMode = Console::isConsole() || $config['circlical']['autowire']['production_mode'];
 
-        if (!$productionMode) {
+        if (!$productionMode || !file_exists($config['circlical']['autowire']['compile_to'])) {
             $routerService = $serviceLocator->get(RouterService::class);
             $directoryScanner = new DirectoryScanner();
 

--- a/src/CirclicalAutoWire/Service/RouterService.php
+++ b/src/CirclicalAutoWire/Service/RouterService.php
@@ -51,6 +51,7 @@ final class RouterService
     public function parseController(string $controllerClass)
     {
         $class = new \ReflectionClass($controllerClass);
+        /** @var Route $classAnnotation */
         $classAnnotation = $this->reader->getClassAnnotation($class, Route::class);
 
         // First, get all annotations for this controller
@@ -58,9 +59,13 @@ final class RouterService
         /** @var \ReflectionMethod $method */
         foreach ($class->getMethods() as $method) {
             if ($method->getDeclaringClass()->getName() == $controllerClass) {
-                $set = $this->reader->getMethodAnnotations($method, Route::class);
+                $set = $this->reader->getMethodAnnotations($method);
                 /** @var Route $routerAnnotation */
                 foreach ($set as $routerAnnotation) {
+                    if (!$routerAnnotation instanceof Route) {
+                        continue;
+                    }
+
                     if ($classAnnotation) {
                         $routerAnnotation->setPrefix($classAnnotation->value);
                     }


### PR DESCRIPTION
Hi,

I wanted to use this library but unfortunately there is a bug in `RouteService`. I don't know wether You either to use `AnnotationReader::getMethodAnnotation` and get just `CirclicalAutoWire\Annotations\Route` or to get all annotations and parse them.

Currently it will fail if You are using any other annotation in Controller.

My change allow multiple declaration of `@Route ` and checks if it is instance of `CirclicalAutoWire\Annotations\Route`.

Regards,