### PR TITLE
Integrate module with zend-component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,10 @@
     "psr-4": {
       "CirclicalAutoWire\\": "src/CirclicalAutoWire"
     }
+  },
+  "extra": {
+    "zf": {
+      "module": "CirclicalAutoWire"
+    }
   }
 }


### PR DESCRIPTION
Zend Framework 3 comes with zend-component-installer as dependency. It allows you to automatically update your modules.config.php with all loaded modules from composer. Thus, wenn installing this module, composer will automatically ask you, if it should add 'CirclicalAutoWire' to the modules.config.php